### PR TITLE
Add index.html for GitHub Pages PDF viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>IoP Workshop Device Codes - フルスクリーン表示</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Hiragino Sans', 'Yu Gothic', 'Meiryo', sans-serif;
+            background-color: #2c3e50;
+            color: white;
+            overflow: hidden;
+        }
+
+        .viewer-container {
+            width: 100vw;
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .viewer-header {
+            background-color: rgba(0, 0, 0, 0.8);
+            padding: 10px 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            backdrop-filter: blur(10px);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .document-title {
+            font-size: 1.1em;
+            font-weight: 600;
+        }
+
+        .viewer-controls {
+            display: flex;
+            gap: 15px;
+            align-items: center;
+        }
+
+        .control-btn {
+            background: rgba(255, 255, 255, 0.1);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            color: white;
+            padding: 8px 12px;
+            border-radius: 6px;
+            text-decoration: none;
+            font-size: 0.9em;
+            transition: all 0.3s ease;
+            cursor: pointer;
+        }
+
+        .control-btn:hover {
+            background: rgba(255, 255, 255, 0.2);
+            border-color: rgba(255, 255, 255, 0.4);
+            text-decoration: none;
+            color: white;
+        }
+
+        .control-btn.github {
+            background: rgba(52, 152, 219, 0.2);
+            border-color: rgba(52, 152, 219, 0.4);
+        }
+
+        .control-btn.github:hover {
+            background: rgba(52, 152, 219, 0.3);
+            border-color: rgba(52, 152, 219, 0.6);
+        }
+
+        .pdf-frame {
+            flex: 1;
+            width: 100%;
+            border: none;
+            background-color: white;
+        }
+
+        .loading-message {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            text-align: center;
+            z-index: 10;
+        }
+
+        .loading-spinner {
+            border: 3px solid rgba(255, 255, 255, 0.3);
+            border-top: 3px solid white;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            animation: spin 1s linear infinite;
+            margin: 0 auto 15px;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+        /* Mobile responsive */
+        @media (max-width: 768px) {
+            .viewer-header {
+                padding: 8px 15px;
+                flex-direction: column;
+                gap: 10px;
+            }
+
+            .document-title {
+                font-size: 1em;
+                text-align: center;
+            }
+
+            .viewer-controls {
+                gap: 10px;
+                flex-wrap: wrap;
+                justify-content: center;
+            }
+
+            .control-btn {
+                padding: 6px 10px;
+                font-size: 0.8em;
+            }
+        }
+
+        /* Error message styles */
+        .error-message {
+            background: rgba(231, 76, 60, 0.1);
+            border: 1px solid rgba(231, 76, 60, 0.3);
+            border-radius: 8px;
+            padding: 20px;
+            margin: 20px;
+            text-align: center;
+        }
+
+        .error-message h3 {
+            color: #e74c3c;
+            margin-bottom: 10px;
+        }
+
+        .fallback-options {
+            margin-top: 20px;
+        }
+
+        .fallback-options a {
+            color: #3498db;
+            text-decoration: none;
+            margin: 0 10px;
+        }
+
+        .fallback-options a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="viewer-container">
+        <div class="viewer-header">
+            <div class="document-title">IoP Workshop Device Codes 資料</div>
+            <div class="viewer-controls">
+                <a href="main.pdf" class="control-btn" download>💾 ダウンロード</a>
+                <a href="main.pdf" class="control-btn" target="_blank">🔗 新しいタブで開く</a>
+                <a href="https://github.com/yonaka15/typst-iop-workshop-device" class="control-btn github" target="_blank">📁 GitHub</a>
+            </div>
+        </div>
+
+        <div class="loading-message" id="loadingMessage">
+            <div class="loading-spinner"></div>
+            <p>PDFを読み込んでいます...</p>
+        </div>
+
+        <iframe
+            src="main.pdf"
+            class="pdf-frame"
+            id="pdfFrame"
+            onload="hideLoading()"
+            onerror="showError()">
+        </iframe>
+    </div>
+
+    <script>
+        function hideLoading() {
+            const loadingMessage = document.getElementById('loadingMessage');
+            if (loadingMessage) {
+                loadingMessage.style.display = 'none';
+            }
+        }
+
+        function showError() {
+            const loadingMessage = document.getElementById('loadingMessage');
+            const pdfFrame = document.getElementById('pdfFrame');
+
+            if (loadingMessage) {
+                loadingMessage.innerHTML = `
+                    <div class="error-message">
+                        <h3>⚠️ PDFの表示に問題が発生しました</h3>
+                        <p>お使いのブラウザまたはデバイスでは、埋め込みPDFの表示がサポートされていない可能性があります。</p>
+                        <div class="fallback-options">
+                            <a href="main.pdf" target="_blank">新しいタブでPDFを開く</a>
+                            <a href="main.pdf" download>PDFをダウンロード</a>
+                            <a href="https://github.com/yonaka15/typst-iop-workshop-device" target="_blank">GitHubリポジトリ</a>
+                        </div>
+                    </div>
+                `;
+            }
+
+            if (pdfFrame) {
+                pdfFrame.style.display = 'none';
+            }
+        }
+
+        // Check if PDF is supported
+        document.addEventListener('DOMContentLoaded', function() {
+            // Hide loading after 10 seconds if not loaded
+            setTimeout(function() {
+                const loadingMessage = document.getElementById('loadingMessage');
+                if (loadingMessage && loadingMessage.style.display !== 'none') {
+                    showError();
+                }
+            }, 10000);
+        });
+
+        // Keyboard shortcuts
+        document.addEventListener('keydown', function(e) {
+            // Ctrl+D for download
+            if (e.ctrlKey && e.key === 'd') {
+                e.preventDefault();
+                window.open('main.pdf', '_blank'); // Changed from download to open in new tab for consistency with button
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds an index.html file to display main.pdf in a viewer, similar to the typst-iop-advance-materials repository. This will allow the repository to be easily viewed via GitHub Pages.